### PR TITLE
Create Fatha ma3azzem screen UI and Handle its logic.

### DIFF
--- a/lib/core/database_helper/boxes_names.dart
+++ b/lib/core/database_helper/boxes_names.dart
@@ -5,6 +5,7 @@ abstract class BoxesNames {
   static const sessionChecks = "SessionChecks";
   static const invitedPeopleHena = "invitedPeopleHena";
   static const invitedPeopleShabka = "invitedPeopleShabka";
+  static const invitedPeopleFatha = "invitedPeopleFatha";
   static const songsFarah = "SongsFarah";
   static const songshena = "SongsHena";
   static const songsShabka = "SongsShabka";

--- a/lib/core/navigation/control_navigation.dart
+++ b/lib/core/navigation/control_navigation.dart
@@ -79,6 +79,9 @@ class ControlNavigation {
         case ScreenNames.arosaDevicesMafroshatScreen:
         Navigator.pushNamed(context, pageName);
         break;
+        case ScreenNames.arosaDevicesHoneymonthScreen:
+        Navigator.pushNamed(context, pageName);
+        break;
       default:
        Navigator.pushNamed(context, ScreenNames.defaultScreen,);
 

--- a/lib/core/navigation/control_navigation.dart
+++ b/lib/core/navigation/control_navigation.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:zaghrota_app/core/navigation/screen_names.dart';
 
 class ControlNavigation {
-  navigationToController({required String pageName,
+  static void navigationToController({required String pageName,
   required BuildContext context,
   dynamic arguments
   }){
@@ -68,6 +68,9 @@ class ControlNavigation {
         Navigator.pushNamed(context, pageName);
         break;
         case ScreenNames.fathaSongsScreen:
+        Navigator.pushNamed(context, pageName);
+        break;
+        case ScreenNames.arosaDevicesBathScreen:
         Navigator.pushNamed(context, pageName);
         break;
       default:

--- a/lib/core/navigation/control_navigation.dart
+++ b/lib/core/navigation/control_navigation.dart
@@ -76,6 +76,9 @@ class ControlNavigation {
         case ScreenNames.arosaDevicesKitchenScreen:
         Navigator.pushNamed(context, pageName);
         break;
+        case ScreenNames.arosaDevicesMafroshatScreen:
+        Navigator.pushNamed(context, pageName);
+        break;
       default:
        Navigator.pushNamed(context, ScreenNames.defaultScreen,);
 

--- a/lib/core/navigation/control_navigation.dart
+++ b/lib/core/navigation/control_navigation.dart
@@ -85,6 +85,9 @@ class ControlNavigation {
         case ScreenNames.arosaDevicesElectroScreen:
         Navigator.pushNamed(context, pageName);
         break;
+        case ScreenNames.modnScreen:
+        Navigator.pushNamed(context, pageName);
+        break;
       default:
        Navigator.pushNamed(context, ScreenNames.defaultScreen,);
 

--- a/lib/core/navigation/control_navigation.dart
+++ b/lib/core/navigation/control_navigation.dart
@@ -73,6 +73,9 @@ class ControlNavigation {
         case ScreenNames.arosaDevicesBathScreen:
         Navigator.pushNamed(context, pageName);
         break;
+        case ScreenNames.arosaDevicesKitchenScreen:
+        Navigator.pushNamed(context, pageName);
+        break;
       default:
        Navigator.pushNamed(context, ScreenNames.defaultScreen,);
 

--- a/lib/core/navigation/control_navigation.dart
+++ b/lib/core/navigation/control_navigation.dart
@@ -88,6 +88,10 @@ class ControlNavigation {
         case ScreenNames.modnScreen:
         Navigator.pushNamed(context, pageName);
         break;
+        case ScreenNames.invitedPeopleFathaScreen:
+        Navigator.pushNamed(context, pageName);
+        break;
+        
       default:
        Navigator.pushNamed(context, ScreenNames.defaultScreen,);
 

--- a/lib/core/navigation/control_navigation.dart
+++ b/lib/core/navigation/control_navigation.dart
@@ -82,6 +82,9 @@ class ControlNavigation {
         case ScreenNames.arosaDevicesHoneymonthScreen:
         Navigator.pushNamed(context, pageName);
         break;
+        case ScreenNames.arosaDevicesElectroScreen:
+        Navigator.pushNamed(context, pageName);
+        break;
       default:
        Navigator.pushNamed(context, ScreenNames.defaultScreen,);
 

--- a/lib/core/navigation/screen_names.dart
+++ b/lib/core/navigation/screen_names.dart
@@ -18,6 +18,7 @@ class ScreenNames {
   static const String arosaDevicesKitchenScreen= "/arosaDevicesKitchenScreen";
   static const String arosaDevicesMafroshatScreen= "/arosaDevicesMafroshatScreen";
   static const String arosaDevicesHoneymonthScreen= "/arosaDevicesHoneyScreen";
+  static const String arosaDevicesElectroScreen= "/arosaDevicesElectroScreen";
   static const String sessionScreen= "/SessionScreen";
   static const String henaScreen= "/HenaScreen";
   static const String mohafzatScreen= "/MohafzatScreen";

--- a/lib/core/navigation/screen_names.dart
+++ b/lib/core/navigation/screen_names.dart
@@ -10,6 +10,7 @@ class ScreenNames {
   static const String invitedPeopleHenaScreen = "/invitedPeopleHenaScreen";
   static const String invitedPeopleScreen = "/invitedPeopleScreen";
   static const String invitedPeopleShabkaScreen = "/invitedPeopleShabkaScreen";
+  static const String invitedPeopleFathaScreen = "/invitedPeopleFathaScreen";
   static const String advertisementScreen= "/advertisementScreen";
   static const String bdlaScreen= "/bdlaScreen";
   static const String dressScreen= "/dressScreen";

--- a/lib/core/navigation/screen_names.dart
+++ b/lib/core/navigation/screen_names.dart
@@ -17,6 +17,7 @@ class ScreenNames {
   static const String arosaDevicesBathScreen= "/arosaDevicesBathScreen";
   static const String arosaDevicesKitchenScreen= "/arosaDevicesKitchenScreen";
   static const String arosaDevicesMafroshatScreen= "/arosaDevicesMafroshatScreen";
+  static const String arosaDevicesHoneymonthScreen= "/arosaDevicesHoneyScreen";
   static const String sessionScreen= "/SessionScreen";
   static const String henaScreen= "/HenaScreen";
   static const String mohafzatScreen= "/MohafzatScreen";

--- a/lib/core/navigation/screen_names.dart
+++ b/lib/core/navigation/screen_names.dart
@@ -22,6 +22,7 @@ class ScreenNames {
   static const String sessionScreen= "/SessionScreen";
   static const String henaScreen= "/HenaScreen";
   static const String mohafzatScreen= "/MohafzatScreen";
+  static const String modnScreen= "/ModnScreen";
   static const String ka3atScreen= "/Ka3atScreen";
   static const String shabkaScreen= "/ShabkaScreen";
   static const String fathacreen= "/FathaScreen";

--- a/lib/core/navigation/screen_names.dart
+++ b/lib/core/navigation/screen_names.dart
@@ -16,6 +16,7 @@ class ScreenNames {
   static const String arosaDevicesScreen= "/arosaDevicesScreen";
   static const String arosaDevicesBathScreen= "/arosaDevicesBathScreen";
   static const String arosaDevicesKitchenScreen= "/arosaDevicesKitchenScreen";
+  static const String arosaDevicesMafroshatScreen= "/arosaDevicesMafroshatScreen";
   static const String sessionScreen= "/SessionScreen";
   static const String henaScreen= "/HenaScreen";
   static const String mohafzatScreen= "/MohafzatScreen";

--- a/lib/core/navigation/screen_names.dart
+++ b/lib/core/navigation/screen_names.dart
@@ -14,6 +14,7 @@ class ScreenNames {
   static const String bdlaScreen= "/bdlaScreen";
   static const String dressScreen= "/dressScreen";
   static const String arosaDevicesScreen= "/arosaDevicesScreen";
+  static const String arosaDevicesBathScreen= "/arosaDevicesBathScreen";
   static const String sessionScreen= "/SessionScreen";
   static const String henaScreen= "/HenaScreen";
   static const String mohafzatScreen= "/MohafzatScreen";

--- a/lib/core/navigation/screen_names.dart
+++ b/lib/core/navigation/screen_names.dart
@@ -15,6 +15,7 @@ class ScreenNames {
   static const String dressScreen= "/dressScreen";
   static const String arosaDevicesScreen= "/arosaDevicesScreen";
   static const String arosaDevicesBathScreen= "/arosaDevicesBathScreen";
+  static const String arosaDevicesKitchenScreen= "/arosaDevicesKitchenScreen";
   static const String sessionScreen= "/SessionScreen";
   static const String henaScreen= "/HenaScreen";
   static const String mohafzatScreen= "/MohafzatScreen";

--- a/lib/features/advertisement_screen/presentation/view/advertisement_screen.dart
+++ b/lib/features/advertisement_screen/presentation/view/advertisement_screen.dart
@@ -19,7 +19,7 @@ class AdvertisementScreen extends StatelessWidget {
       appBar: const CustomAppBar(),
       body: GestureDetector(
         onTap: () {
-          ControlNavigation().navigationToController(pageName:pageName , context: context);
+          ControlNavigation.navigationToController(pageName:pageName , context: context);
         },
         child: Center(
           child: Column(

--- a/lib/features/arosa_devices_bathroom_screen/presentation/view/arosa_devices_bath_screen.dart
+++ b/lib/features/arosa_devices_bathroom_screen/presentation/view/arosa_devices_bath_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
+import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart';
+import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
+
+class ArosaDevicesBathScreen extends StatelessWidget {
+  const ArosaDevicesBathScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SafeArea(
+      child: Scaffold(
+        backgroundColor: AppColors.scaffoldColor,
+          appBar: CustomAppBar(),
+          body: SingleChildScrollView(
+            child: CustomListView(),
+          ),
+    ));
+  }
+}

--- a/lib/features/arosa_devices_bathroom_screen/presentation/view/widgets/cusom_item.dart
+++ b/lib/features/arosa_devices_bathroom_screen/presentation/view/widgets/cusom_item.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
+import 'package:zaghrota_app/core/textstyles/textstyles.dart';
+import 'package:zaghrota_app/core/usable/sizedbox.dart';
+
+class CustomItem extends StatelessWidget {
+  const CustomItem({super.key, required this.itemName, required this.checked, this.deleteOnPressed, this.checkOnChanged});
+  final String itemName;
+  final bool checked;
+  final void Function()? deleteOnPressed;
+  final void Function(bool?)? checkOnChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return  Container(
+              padding: EdgeInsets.symmetric(vertical: 10.sp,horizontal: 5.sp),
+              decoration: BoxDecoration(
+                border: Border.all(color: AppColors.circleAvatarBorderColor)
+              ),
+              width: 1.sw,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  SizedBox(
+                    width: 0.4.sw,
+                    child:Row(
+                      // mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                       Transform.scale(scale: 1.sp,child: Image.asset('assets/images/badlascreen_images/Chec_Mark.png'),),
+                       HorizontalSizedBox(width: 10.sp),
+                       Container(
+                        constraints: BoxConstraints(maxWidth: 0.3.sw),
+                        child: Text(itemName,style: Textstyles.nameOfInvitedPeopleStyle,))
+                      ],
+                    ) ,
+                  ),
+                  Text("x12",style: Textstyles.weddingNames,),
+                     Checkbox(
+                                    
+                                     activeColor: AppColors.checkBoxActiveColor,
+                                    //  checkColor: AppColors.checkBoxCheckColor,
+                                     side: const BorderSide(color: AppColors.checkBoxActiveColor),
+                                     value: checked,
+                     
+                                    onChanged:checkOnChanged
+                                   ),
+          IconButton(
+          iconSize: 20.sp,
+          onPressed:deleteOnPressed
+          
+          , icon: const Icon(
+          
+          Icons.delete,color: AppColors.circleAvatarBorderColor,))
+                    
+                ],
+              ),
+            );
+  }
+}

--- a/lib/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart
+++ b/lib/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:zaghrota_app/core/usable/sizedbox.dart';
+import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/widgets/cusom_item.dart';
+
+class CustomListView extends StatelessWidget {
+  const CustomListView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return  Padding(
+      padding: EdgeInsets.symmetric(horizontal: 5.sp,vertical: 10.sp),
+      child: ListView.separated(
+        separatorBuilder: (context, index) => const VerticalSizedBox(height: 10),
+        shrinkWrap: true,
+        itemCount: 20,
+        physics: const NeverScrollableScrollPhysics(),
+        itemBuilder: (context, index) => const CustomItem(itemName: "طقم دواسات", checked: false),),
+    );
+  }
+}

--- a/lib/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart
+++ b/lib/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart
@@ -4,8 +4,8 @@ import 'package:zaghrota_app/core/usable/sizedbox.dart';
 import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/widgets/cusom_item.dart';
 
 class CustomListView extends StatelessWidget {
-  const CustomListView({super.key});
-
+  const CustomListView({super.key, required this.deleteOnPressed});
+ final Function(int) deleteOnPressed;
   @override
   Widget build(BuildContext context) {
     return  Padding(
@@ -15,7 +15,10 @@ class CustomListView extends StatelessWidget {
         shrinkWrap: true,
         itemCount: 20,
         physics: const NeverScrollableScrollPhysics(),
-        itemBuilder: (context, index) => const CustomItem(itemName: "طقم دواسات", checked: false),),
+        itemBuilder: (context, index) => CustomItem(itemName: "طقم دواسات", checked: false,
+        deleteOnPressed: () {
+          deleteOnPressed(index);
+        },),),
     );
   }
 }

--- a/lib/features/arosa_devices_electronics_screen/presentation/view/arosa_devices_electronics_screen.dart
+++ b/lib/features/arosa_devices_electronics_screen/presentation/view/arosa_devices_electronics_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
+import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart';
+import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
+
+class ArosaDevicesElectronicsScreen extends StatelessWidget {
+  const ArosaDevicesElectronicsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        backgroundColor: AppColors.scaffoldColor,
+          appBar: const CustomAppBar(),
+          body: SingleChildScrollView(
+            child: CustomListView(
+             deleteOnPressed:  (index){
+   
+              },
+            ),
+          ),
+    ));  }
+}

--- a/lib/features/arosa_devices_honeymonth_screen/presentation/view/arosa_devices_honemonth_screen.dart
+++ b/lib/features/arosa_devices_honeymonth_screen/presentation/view/arosa_devices_honemonth_screen.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
+import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart';
+import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
+
+class ArosaDevicesHonemonthScreen extends StatelessWidget {
+  const ArosaDevicesHonemonthScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        backgroundColor: AppColors.scaffoldColor,
+          appBar: const CustomAppBar(),
+          body: SingleChildScrollView(
+            child: CustomListView(
+             deleteOnPressed:  (index){
+   
+              },
+            ),
+          ),
+    ));
+  }
+}

--- a/lib/features/arosa_devices_kitchen_screen/presentation/view/arosa_devices_kitchen_screen.dart
+++ b/lib/features/arosa_devices_kitchen_screen/presentation/view/arosa_devices_kitchen_screen.dart
@@ -3,18 +3,18 @@ import 'package:zaghrota_app/core/colors/colors.dart';
 import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart';
 import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
 
-class ArosaDevicesBathScreen extends StatelessWidget {
-  const ArosaDevicesBathScreen({super.key});
+class ArosaDevicesKitchenScreen extends StatelessWidget {
+  const ArosaDevicesKitchenScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return  SafeArea(
+    return SafeArea(
       child: Scaffold(
         backgroundColor: AppColors.scaffoldColor,
           appBar: const CustomAppBar(),
           body: SingleChildScrollView(
             child: CustomListView(
-              deleteOnPressed: (index){
+             deleteOnPressed:  (index){
    
               },
             ),

--- a/lib/features/arosa_devices_mafroshat_screen/presentation/view/arosa_devices_mafroshat_screen.dart
+++ b/lib/features/arosa_devices_mafroshat_screen/presentation/view/arosa_devices_mafroshat_screen.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
+import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/widgets/custom_list_view.dart';
+import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
+
+class ArosaDevicesMafroshatScreen extends StatelessWidget {
+  const ArosaDevicesMafroshatScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        backgroundColor: AppColors.scaffoldColor,
+          appBar: const CustomAppBar(),
+          body: SingleChildScrollView(
+            child: CustomListView(
+             deleteOnPressed:  (index){
+   
+              },
+            ),
+          ),
+    ));
+  }
+}

--- a/lib/features/arosa_devices_screen/presentation/view/arosa_devices_screen.dart
+++ b/lib/features/arosa_devices_screen/presentation/view/arosa_devices_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
 import 'package:zaghrota_app/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart';
 import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
 
@@ -8,8 +9,9 @@ class ArosaDevicesScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
   
-    return const SafeArea(
+    return  const SafeArea(
       child: Scaffold(
+        backgroundColor: AppColors.scaffoldColor,
         appBar: CustomAppBar(),
         body: SingleChildScrollView(
           child: ArosaDevicesGridview()

--- a/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
+++ b/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:zaghrota_app/core/navigation/control_navigation.dart';
+import 'package:zaghrota_app/core/navigation/screen_names.dart';
 import 'package:zaghrota_app/features/arosa_devices_screen/presentation/view/widgets/arosa_gridview_item.dart';
 
 class ArosaDevicesGridview extends StatelessWidget {
@@ -10,27 +12,33 @@ class ArosaDevicesGridview extends StatelessWidget {
       List data = [
       {
         "img":"assets/images/arosa_devices_image/Kitchenfood.png",
-        "title":"المطبخ"
+        "title":"المطبخ",
+        "nav":""
       },
       {
         "img":"assets/images/arosa_devices_image/blue.png",
-        "title":"الحمام"
+        "title":"الحمام",
+        "nav":ScreenNames.arosaDevicesBathScreen
       },
       {
         "img":"assets/images/arosa_devices_image/bedroom.png",
-        "title":"المفروشات"
+        "title":"المفروشات",
+        "nav":""
       },
       {
         "img":"assets/images/arosa_devices_image/couple.png",
-        "title":"شهر العسل"
+        "title":"شهر العسل",
+         "nav":""
       },
       {
         "img":"assets/images/arosa_devices_image/clothes.png",
-        "title":"الملابس"
+        "title":"الملابس",
+        "nav":""
       },
       {
         "img":"assets/images/arosa_devices_image/socket.png",
-        "title":"أجهزة كهربائية"
+        "title":"أجهزة كهربائية",
+        "nav":""
       },
     ];
     return Padding(
@@ -43,7 +51,11 @@ class ArosaDevicesGridview extends StatelessWidget {
                 mainAxisSpacing: 15.h,
                 crossAxisSpacing: 10.w,
                 crossAxisCount: 2),
-             itemBuilder: (context, index) => ArosaGridviewItem(img: data[index]["img"], title: data[index]["title"]),
+             itemBuilder: (context, index) => GestureDetector(
+              onTap:() {
+                ControlNavigation.navigationToController(pageName: data[index]["nav"], context: context);
+              } ,
+              child: ArosaGridviewItem(img: data[index]["img"], title: data[index]["title"])),
              itemCount: data.length,
              ),
     );

--- a/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
+++ b/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
@@ -38,7 +38,7 @@ class ArosaDevicesGridview extends StatelessWidget {
       {
         "img":"assets/images/arosa_devices_image/socket.png",
         "title":"أجهزة كهربائية",
-        "nav":""
+        "nav":ScreenNames.arosaDevicesElectroScreen
       },
     ];
     return Padding(

--- a/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
+++ b/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
@@ -13,7 +13,7 @@ class ArosaDevicesGridview extends StatelessWidget {
       {
         "img":"assets/images/arosa_devices_image/Kitchenfood.png",
         "title":"المطبخ",
-        "nav":""
+        "nav":ScreenNames.arosaDevicesKitchenScreen
       },
       {
         "img":"assets/images/arosa_devices_image/blue.png",

--- a/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
+++ b/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
@@ -28,7 +28,7 @@ class ArosaDevicesGridview extends StatelessWidget {
       {
         "img":"assets/images/arosa_devices_image/couple.png",
         "title":"شهر العسل",
-         "nav":""
+         "nav":ScreenNames.arosaDevicesHoneymonthScreen
       },
       {
         "img":"assets/images/arosa_devices_image/clothes.png",

--- a/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
+++ b/lib/features/arosa_devices_screen/presentation/view/widgets/arosa_devices_gridview.dart
@@ -23,7 +23,7 @@ class ArosaDevicesGridview extends StatelessWidget {
       {
         "img":"assets/images/arosa_devices_image/bedroom.png",
         "title":"المفروشات",
-        "nav":""
+        "nav":ScreenNames.arosaDevicesMafroshatScreen
       },
       {
         "img":"assets/images/arosa_devices_image/couple.png",

--- a/lib/features/fatha_ma3azzem_screen/data/repo/fatha_ma3azeem_repo.dart
+++ b/lib/features/fatha_ma3azzem_screen/data/repo/fatha_ma3azeem_repo.dart
@@ -1,0 +1,83 @@
+import 'package:dartz/dartz.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:zaghrota_app/core/database_helper/boxes_names.dart';
+import 'package:zaghrota_app/core/database_helper/hive_usable.dart';
+import 'package:zaghrota_app/features/invited_people_screen/data/model/error_model.dart';
+import 'package:zaghrota_app/features/invited_people_screen/data/model/invited_model.dart';
+
+class FathaMa3azeemRepo {
+    HiveStorage hiive = HiveStorage();
+
+  Future<Either<ErrorModel,void>> addInvitedPeople(InvitedModel inviteData)async {
+  try {
+    await hiive.addValue<InvitedModel>(boxName: BoxesNames.invitedPeopleFatha, value: inviteData);
+    return right(null);
+  }
+  on HiveError catch (e){
+    return left(ErrorModel(errormsg: "The error from hive is $e"));
+
+  }
+   catch (e) {
+    return left(ErrorModel(errormsg: "The error is $e"));
+  }
+  }
+
+
+Either<ErrorModel,List<InvitedModel>> getInvitedPeople(){
+  try {
+    List<InvitedModel> data = hiive.getBoxValues<InvitedModel>(boxName: BoxesNames.invitedPeopleFatha) as List<InvitedModel>;
+    return right(data);
+  }
+    on HiveError catch (e){
+    return left(ErrorModel(errormsg: "The error from hive is $e"));
+
+  }
+   catch (e) {
+    return left(ErrorModel(errormsg: "The error is $e"));
+  
+  }
+
+}
+
+Future<Either<ErrorModel,void>> updateCheckedValue({required int index,required dynamic value})async{
+  try {
+    List data = hiive.getBoxValues<InvitedModel>(boxName: BoxesNames.invitedPeopleFatha);
+    if(data.isNotEmpty){
+    await hiive.updateItem<InvitedModel>(boxName: BoxesNames.invitedPeopleFatha, index: index, value:value);
+    return right(null);
+    }
+    else{
+      return right(null);
+    }
+  }
+    on HiveError catch (e){
+    return left(ErrorModel(errormsg: "The error from hive is $e"));
+
+  }
+   catch (e) {
+    return left(ErrorModel(errormsg: "The error is $e"));
+    
+  }
+  
+}
+
+Future<Either<ErrorModel,Null>> deleteValue({required int index})async{
+  try {
+    // List data = hiive.getBoxValues(boxName: BoxesNames.invitedPeopleFatha);
+    
+    await hiive.deleteItem<InvitedModel>(boxName: BoxesNames.invitedPeopleFatha, index: index);
+    return right(null);
+    
+    
+  }
+    on HiveError catch (e){
+    return left(ErrorModel(errormsg: "The error from hive is $e"));
+
+  }
+   catch (e) {
+    return left(ErrorModel(errormsg: "The error is $e"));
+    
+  }
+  
+}
+}

--- a/lib/features/fatha_ma3azzem_screen/presentation/view/fatha_ma3aazeem_invited_people_screen.dart
+++ b/lib/features/fatha_ma3azzem_screen/presentation/view/fatha_ma3aazeem_invited_people_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
+import 'package:zaghrota_app/features/fatha_ma3azzem_screen/presentation/view/widgets/fatha_invited_people_listview.dart';
+import 'package:zaghrota_app/features/fatha_ma3azzem_screen/presentation/view_model/cubit/fatha_invited_people_screen_cubit.dart';
+import 'package:zaghrota_app/features/invited_people_hena_screen/presentation/view/widgets/invited_people_hena_appbar.dart';
+import 'package:zaghrota_app/features/invited_people_screen/presentation/view/widgets/dialogs/floating_add_button.dart';
+import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/songs_top_titles_item_view.dart';
+
+class FathaMa3aazeemInvitedPeopleScreen extends StatelessWidget {
+  const FathaMa3aazeemInvitedPeopleScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+        child: Scaffold(
+          backgroundColor: AppColors.scaffoldColor,
+      floatingActionButton:
+          BlocConsumer<FathaInvitedPeopleScreenCubit, FathaInvitedPeopleScreenState>(
+        listener: (context, state) {},
+        builder: (context, state) {
+          FathaInvitedPeopleScreenCubit cubit = FathaInvitedPeopleScreenCubit.get(context);
+          return AddDataDialogue(
+            namecontroller: cubit.controlName,
+            numbercontroller: cubit.controlNumber,
+            formKey: cubit.formKey,
+            onChanged: (p0) {},
+            addData: () {
+              cubit.addInvitedPeople();
+            },
+          );
+        },
+      ),
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(60.h),
+        child: BlocBuilder<FathaInvitedPeopleScreenCubit, FathaInvitedPeopleScreenState>(
+          builder: (context, state) {
+            if (state is GetFathaInvitedPeopleScreenSucess) {
+              return InvitedPeopleHenaAppbar(sumNum: state.numberOfComings,);
+            }
+            else{
+              return const Text("");
+            }
+          },
+        ),
+      ),
+      body: const SingleChildScrollView(
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                SongsTopTitlesItemView(title: "اسم المدعو"),
+                SongsTopTitlesItemView(title: "عدد التابعين"),
+                SongsTopTitlesItemView(title: "تأكيد الحضور"),
+              ],
+            ),
+            FathaInvitedPeopleListvieew()
+          ],
+        ),
+      ),
+    ));
+  }
+}

--- a/lib/features/fatha_ma3azzem_screen/presentation/view/widgets/fatha_invited_people_listview.dart
+++ b/lib/features/fatha_ma3azzem_screen/presentation/view/widgets/fatha_invited_people_listview.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
+import 'package:zaghrota_app/core/textstyles/textstyles.dart';
+import 'package:zaghrota_app/core/usable/sizedbox.dart';
+import 'package:zaghrota_app/features/fatha_ma3azzem_screen/presentation/view_model/cubit/fatha_invited_people_screen_cubit.dart';
+import 'package:zaghrota_app/features/invited_people_screen/data/model/invited_model.dart';
+import 'package:zaghrota_app/features/invited_people_screen/presentation/view/widgets/visitor_item.dart';
+
+class FathaInvitedPeopleListvieew extends StatelessWidget {
+  const FathaInvitedPeopleListvieew({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<FathaInvitedPeopleScreenCubit, FathaInvitedPeopleScreenState>(
+      listener: (context, state) {
+        
+      },
+      builder: (context, state) {
+        var cubit = FathaInvitedPeopleScreenCubit.get(context);
+        if(state is GetFathaInvitedPeopleScreenFailure){
+          return Center(child: Text("Failed!:${state.errormsg}"));
+        }
+        else if(state is GetFathaInvitedPeopleScreenSucess){
+          List<InvitedModel> data = state.invitedPeopleData;
+        return ListView.separated(
+          shrinkWrap: true,
+          itemBuilder: (context, index) => Padding(
+            padding: EdgeInsets.all(10.sp),
+            child:  VisitorItem(
+              onPressed: () async{
+                deleteDialog(context, cubit, index);
+               
+              },
+              onChanged: (p0) {
+                data[index].checked=p0!;
+                cubit.updateCheck(index: index, value: InvitedModel(name: data[index].name,
+                 numberOfInvitedPeople: data[index].numberOfInvitedPeople,
+                 checked: data[index].checked));
+              },
+              name: data[index].name,
+            numbersOfPeople:data[index].numberOfInvitedPeople,
+            checked: data[index].checked,),
+          ),
+          itemCount: state.invitedPeopleData.length,
+          separatorBuilder: (context, index) =>
+            const VerticalSizedBox(height: 5),
+        );
+      }
+      else{
+        return const Center(child: CircularProgressIndicator(
+          color: AppColors.circleAvatarBorderColor,
+        ),);
+      }
+      },
+    );
+  }
+
+  void deleteDialog(BuildContext context, FathaInvitedPeopleScreenCubit cubit, int index) {
+            showDialog(context: context, builder: (context) => AlertDialog(
+          title: Center(child: Text("تأكيد الحذف",style: Textstyles.nameOfInvitedPeopleStyle,)),
+          content: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+            SizedBox(
+              width: 0.5.sw,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.green
+                ),
+                onPressed: ()async {
+                 await cubit.deleteItem(index: index);
+                  // ignore: use_build_context_synchronously
+                  Navigator.pop(context);
+                },
+                 child: Text("نعم",style: Textstyles.songsTopTitleStyle,)),
+            ),
+          const VerticalSizedBox(height: 1),
+          SizedBox(
+            width: 0.5.sw,
+            child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red
+                ),
+                onPressed: () {
+              Navigator.pop(context);
+            }, child: Text("لا",style: Textstyles.songsTopTitleStyle,)),
+          )
+          
+          ],),
+        ),);
+  }
+}

--- a/lib/features/fatha_ma3azzem_screen/presentation/view_model/cubit/fatha_invited_people_screen_cubit.dart
+++ b/lib/features/fatha_ma3azzem_screen/presentation/view_model/cubit/fatha_invited_people_screen_cubit.dart
@@ -1,0 +1,76 @@
+import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:meta/meta.dart';
+import 'package:zaghrota_app/features/fatha_ma3azzem_screen/data/repo/fatha_ma3azeem_repo.dart';
+import 'package:zaghrota_app/features/invited_people_screen/data/model/invited_model.dart';
+
+part 'fatha_invited_people_screen_state.dart';
+
+class FathaInvitedPeopleScreenCubit extends Cubit<FathaInvitedPeopleScreenState> {
+  FathaInvitedPeopleScreenCubit() : super(FathaInvitedPeopleScreenInitial());
+   final FathaMa3azeemRepo repo = FathaMa3azeemRepo();
+  static FathaInvitedPeopleScreenCubit get(context)=> BlocProvider.of<FathaInvitedPeopleScreenCubit>(context);
+GlobalKey<FormState> formKey = GlobalKey();
+TextEditingController controlName = TextEditingController();
+TextEditingController controlNumber = TextEditingController();
+
+
+  Future<void> addInvitedPeople()async{
+    InvitedModel inviteedModel = InvitedModel(name: controlName.text, numberOfInvitedPeople:int.parse(controlNumber.text.toString()));
+    emit(AddFathaInvitedPeopleScreenLoading());
+   var result = await repo.addInvitedPeople(inviteedModel);
+   result.fold((l){
+    emit(AddFathaInvitedPeopleScreenError(errormsg: l.errormsg));
+   }, (r) {
+    getInvitedPeople();
+   } ,);
+
+
+  } 
+
+  getInvitedPeople(){
+      print("get item Start====>>>> ");
+
+    emit(GetFathaInvitedPeopleScreenLoading());
+    var result = repo.getInvitedPeople();
+    result.fold((l) {
+      print("get item failure====>>>> ");
+
+      emit(GetFathaInvitedPeopleScreenFailure(errormsg:l.errormsg ));
+    },
+     (r) {
+      print("get item Success====>>>> ");
+
+      int total = 0;
+      for(int x=0;x<r.length;x++){
+        if(r[x].checked){
+         total=total+ r[x].numberOfInvitedPeople;
+         }
+      }
+      emit(GetFathaInvitedPeopleScreenSucess(invitedPeopleData:r ,numberOfComings: total));
+    },);
+  }
+
+  updateCheck({required int index,required InvitedModel value})async {
+    var result = await repo.updateCheckedValue(index: index, value: value);
+    result.fold((l) {
+      emit(GetFathaInvitedPeopleScreenFailure(errormsg: l.errormsg));
+    },(r) {
+      getInvitedPeople();
+    },);
+  }
+    deleteItem({required int index})async {
+      print("Delete item Start====>>>> ");
+    var result = await repo.deleteValue(index: index,);
+    result.fold((l) {
+      print("Delete item fail====>>>> ");
+      
+      emit(GetFathaInvitedPeopleScreenFailure(errormsg: l.errormsg));
+    },(r) {
+      print("Delete item Success====>>>> ");
+
+      getInvitedPeople();
+    },);
+  }
+}

--- a/lib/features/fatha_ma3azzem_screen/presentation/view_model/cubit/fatha_invited_people_screen_state.dart
+++ b/lib/features/fatha_ma3azzem_screen/presentation/view_model/cubit/fatha_invited_people_screen_state.dart
@@ -1,0 +1,30 @@
+part of 'fatha_invited_people_screen_cubit.dart';
+
+@immutable
+sealed class FathaInvitedPeopleScreenState {}
+
+final class FathaInvitedPeopleScreenInitial extends FathaInvitedPeopleScreenState {}
+final class AddFathaInvitedPeopleScreenLoading extends FathaInvitedPeopleScreenInitial {}
+final class AddFathaInvitedPeopleScreenSucess extends FathaInvitedPeopleScreenInitial {}
+final class AddFathaInvitedPeopleScreenError extends FathaInvitedPeopleScreenInitial {
+  final String errormsg;
+
+  AddFathaInvitedPeopleScreenError({required this.errormsg});
+}
+
+
+ //* Get Data states
+final class GetFathaInvitedPeopleScreenLoading extends FathaInvitedPeopleScreenInitial {}
+
+final class GetFathaInvitedPeopleScreenSucess extends FathaInvitedPeopleScreenInitial {
+  final List<InvitedModel> invitedPeopleData;
+  final int numberOfComings;
+
+  GetFathaInvitedPeopleScreenSucess({required this.numberOfComings, required this.invitedPeopleData});
+}
+
+final class GetFathaInvitedPeopleScreenFailure extends FathaInvitedPeopleScreenInitial {
+  final String errormsg;
+
+  GetFathaInvitedPeopleScreenFailure({required this.errormsg});
+}

--- a/lib/features/fatha_screen/presentation/view/fatha_screen.dart
+++ b/lib/features/fatha_screen/presentation/view/fatha_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
 import 'package:zaghrota_app/features/fatha_screen/presentation/view/widgets/fatha_listview.dart';
 import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
 
@@ -8,6 +9,7 @@ class FathaScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const SafeArea(child: Scaffold(
+      backgroundColor: AppColors.scaffoldColor,
       appBar: CustomAppBar(),
       body: SingleChildScrollView(
         child: FathaListview()

--- a/lib/features/fatha_screen/presentation/view/widgets/fatha_listview.dart
+++ b/lib/features/fatha_screen/presentation/view/widgets/fatha_listview.dart
@@ -64,7 +64,7 @@ class FathaListview extends StatelessWidget {
                 alignment: isArabic()? index%2==0?AlignmentDirectional.centerEnd:AlignmentDirectional.centerStart :index%2==0?AlignmentDirectional.centerStart:AlignmentDirectional.centerEnd ,
                 child: GestureDetector(
                   onTap: () {
-                    ControlNavigation().navigationToController(pageName: listviewData[index]["navigation"], context: context);
+                    ControlNavigation.navigationToController(pageName: listviewData[index]["navigation"], context: context);
                   },
                   child: Container(
                     width: 0.7.sw,

--- a/lib/features/fatha_screen/presentation/view/widgets/fatha_listview.dart
+++ b/lib/features/fatha_screen/presentation/view/widgets/fatha_listview.dart
@@ -30,7 +30,7 @@ class FathaListview extends StatelessWidget {
     "image":"assets/images/wedding_items_screen_images/Envelope_with_postcard_serpentine_ribbon_and_paper_bow_for_decorating_gifts.png",
     "height":200.h,
     "width":169.w,
-    "navigation":""
+    "navigation":ScreenNames.invitedPeopleFathaScreen
     },
     {
     "title":"ديكورات",

--- a/lib/features/fatha_songs_screen/presentation/view_model/cubit/fatha_songs_screen_cubit.dart
+++ b/lib/features/fatha_songs_screen/presentation/view_model/cubit/fatha_songs_screen_cubit.dart
@@ -1,8 +1,6 @@
-import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:meta/meta.dart';
 import 'package:zaghrota_app/core/database_helper/boxes_names.dart';
 import 'package:zaghrota_app/features/fatha_songs_screen/data/repo/fatha_songs_screen_repo.dart';
 import 'package:zaghrota_app/features/songs_screen/data/models/song_model.dart';

--- a/lib/features/hena_screen/presentation/view/hena_screen.dart
+++ b/lib/features/hena_screen/presentation/view/hena_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
 import 'package:zaghrota_app/features/hena_screen/presentation/view/widgets/hena_listview.dart';
 import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
 
@@ -8,6 +9,7 @@ class HenaScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
+      backgroundColor: AppColors.scaffoldColor,
       appBar: CustomAppBar(),
       body: SingleChildScrollView(
         child: HenaItemsChoicesListview()

--- a/lib/features/hena_screen/presentation/view/widgets/hena_listview.dart
+++ b/lib/features/hena_screen/presentation/view/widgets/hena_listview.dart
@@ -64,7 +64,7 @@ class HenaItemsChoicesListview extends StatelessWidget {
                 alignment: isArabic()? index%2==0?AlignmentDirectional.centerEnd:AlignmentDirectional.centerStart :index%2==0?AlignmentDirectional.centerStart:AlignmentDirectional.centerEnd ,
                 child: GestureDetector(
                   onTap: () {
-                    ControlNavigation().navigationToController(pageName: listviewData[index]["navigation"], context: context);
+                    ControlNavigation.navigationToController(pageName: listviewData[index]["navigation"], context: context);
                   },
                   child: Container(
                     width: 0.7.sw,

--- a/lib/features/home_screen/presentation/view/widgets/home_gridview_item.dart
+++ b/lib/features/home_screen/presentation/view/widgets/home_gridview_item.dart
@@ -55,7 +55,7 @@ class HomeGridviewItem extends StatelessWidget {
 //                children: [
 //                 GestureDetector(
 //                   onTap: () {
-//                     ControlNavigation().navigationToController(pageName: listviewData[index]["navigation"], context: context,arguments: args);
+//                     ControlNavigation.navigationToController(pageName: listviewData[index]["navigation"], context: context,arguments: args);
 //                   },
 //                   child: Stack(
 //                     children: [

--- a/lib/features/home_screen/presentation/view/widgets/homechoices_listview.dart
+++ b/lib/features/home_screen/presentation/view/widgets/homechoices_listview.dart
@@ -59,7 +59,7 @@ class HomechoicesListview extends StatelessWidget {
                 crossAxisCount: 2),
              itemBuilder: (context, index) => GestureDetector(
               onTap: () {
-                ControlNavigation().navigationToController(pageName: listviewData[index]["navigation"], context: context);
+                ControlNavigation.navigationToController(pageName: listviewData[index]["navigation"], context: context);
               },
                child: HomeGridviewItem(
                 img: listviewData[index]["image"], title: listviewData[index]["title"]),

--- a/lib/features/login_screen/presentation/view/widgets/form_textfields.dart
+++ b/lib/features/login_screen/presentation/view/widgets/form_textfields.dart
@@ -90,7 +90,7 @@ class _FormTextfieldsState extends State<FormTextfields> {
                   SignInButton(
                     onPressed: () {
                   if(keey.currentState!.validate()){
-                  ControlNavigation().navigationToController(pageName: ScreenNames.homeScreen,context:context,
+                  ControlNavigation.navigationToController(pageName: ScreenNames.homeScreen,context:context,
                   arguments:   entrydate==null?[aresName,arosName,DateTime.now()]:[aresName,arosName,entrydate]);
                   }
                     },

--- a/lib/features/mohafazat_modn_screen/presentation/view/mohafzat_modn_screen.dart
+++ b/lib/features/mohafazat_modn_screen/presentation/view/mohafzat_modn_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
+import 'package:zaghrota_app/features/mohafazat_modn_screen/presentation/view/widgets/modn_gridview.dart';
+import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
+
+class MohafzatModnScreen extends StatelessWidget {
+  const MohafzatModnScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SafeArea(
+      child: Scaffold(
+        backgroundColor: AppColors.scaffoldColor,
+        appBar: CustomAppBar(),
+        body: SingleChildScrollView(
+          child: ModnGridview()
+        ) ,
+      ));
+  }
+}

--- a/lib/features/mohafazat_modn_screen/presentation/view/widgets/modn_gridview.dart
+++ b/lib/features/mohafazat_modn_screen/presentation/view/widgets/modn_gridview.dart
@@ -4,8 +4,9 @@ import 'package:zaghrota_app/core/navigation/control_navigation.dart';
 import 'package:zaghrota_app/core/navigation/screen_names.dart';
 import 'package:zaghrota_app/features/mohafzat_screen/presentation/view/mohafzat_item.dart';
 
-class MohafzatGridview extends StatelessWidget {
-  const MohafzatGridview({super.key});
+
+class ModnGridview extends StatelessWidget {
+  const ModnGridview({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -20,11 +21,12 @@ class MohafzatGridview extends StatelessWidget {
           mainAxisSpacing: 10.h
           ),
           itemBuilder: (context, index) => MohafzatItem(
-            onTap:() {
-        ControlNavigation.navigationToController(pageName: ScreenNames.modnScreen, context: context);
-      } ,
-
-            location: "محافظة الغربية",
+            onTap: () {
+              
+        ControlNavigation.navigationToController(pageName: ScreenNames.ka3atScreen, context: context);
+      
+            },
+            location: "مدينة طنطا",
             index: index),
           itemCount: 5,
           

--- a/lib/features/mohafzat_screen/presentation/view/mohafzat_item.dart
+++ b/lib/features/mohafzat_screen/presentation/view/mohafzat_item.dart
@@ -1,19 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:zaghrota_app/core/colors/colors.dart';
-import 'package:zaghrota_app/core/navigation/control_navigation.dart';
-import 'package:zaghrota_app/core/navigation/screen_names.dart';
 import 'package:zaghrota_app/core/textstyles/textstyles.dart';
 
 class MohafzatItem extends StatelessWidget {
-  const MohafzatItem({super.key, required this.index});
+  const MohafzatItem({super.key, required this.index, required this.location, this.onTap});
  final int index;
+ final String location;
+ final void Function()? onTap;
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        ControlNavigation.navigationToController(pageName: ScreenNames.ka3atScreen, context: context);
-      },
+      onTap: onTap,
       child: ClipRRect(
               
               borderRadius: BorderRadius.circular(15.sp),
@@ -34,7 +32,7 @@ class MohafzatItem extends StatelessWidget {
                     Image(image: const AssetImage("assets/images/mohafzat_screen_images/ka3a.png"),width: 0.4.sw,
                     height: 0.2.sh,
                     ),
-                    Text("محافظة الغربية",style: Textstyles.blackStroke,)
+                    Text(location,style: Textstyles.blackStroke,)
                   ],
                 ),
               ),

--- a/lib/features/mohafzat_screen/presentation/view/mohafzat_item.dart
+++ b/lib/features/mohafzat_screen/presentation/view/mohafzat_item.dart
@@ -12,7 +12,7 @@ class MohafzatItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        ControlNavigation().navigationToController(pageName: ScreenNames.ka3atScreen, context: context);
+        ControlNavigation.navigationToController(pageName: ScreenNames.ka3atScreen, context: context);
       },
       child: ClipRRect(
               

--- a/lib/features/session_screen/data/repo/session_screen_repo.dart
+++ b/lib/features/session_screen/data/repo/session_screen_repo.dart
@@ -24,7 +24,7 @@ Either<ErrorModel,List<bool>> getData (){
 
 Future<Either<ErrorModel,void>> addData({required bool value})async{
   List<bool> data = hiive.getBoxValues<bool>(boxName: BoxesNames.sessionChecks) as List<bool>;
-  if (data.length<16){
+  if (data.length<22){
     try{
       await hiive.addValue<bool>(boxName: BoxesNames.sessionChecks, value:value );
       return right(null);

--- a/lib/features/session_screen/presentation/view/session_screen.dart
+++ b/lib/features/session_screen/presentation/view/session_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
 import 'package:zaghrota_app/features/session_screen/presentation/view/widgets/session_screen_gridview.dart';
 import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
 
@@ -8,6 +9,7 @@ class SessionScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
+      backgroundColor: AppColors.scaffoldColor,
       appBar: CustomAppBar(),
       body: SingleChildScrollView(
         child: SessionScreenGridviewBuilder()),

--- a/lib/features/session_screen/presentation/view/widgets/session_screen_gridview.dart
+++ b/lib/features/session_screen/presentation/view/widgets/session_screen_gridview.dart
@@ -131,10 +131,14 @@ class SessionScreenGridviewBuilder extends StatelessWidget {
               value: value,
               onChanged: (p0) {
                 if(index<state.dataChecks.length){
+                print(state.dataChecks.toString());
+
                 cubit.updateCheckedValue(index: index, value: p0!);
                 
                }
                else{
+                print(state.dataChecks.length);
+                print(index);
                 cubit.addData(value:p0! );
                }
               },

--- a/lib/features/shabka_screen/presentation/view/shabka_screen.dart
+++ b/lib/features/shabka_screen/presentation/view/shabka_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:zaghrota_app/core/colors/colors.dart';
 import 'package:zaghrota_app/features/shabka_screen/presentation/view/widgets/shabka_listview.dart';
 import 'package:zaghrota_app/features/songs_screen/presentation/view/widgets/custom_app_bar.dart';
 
@@ -8,6 +9,7 @@ class ShabkaScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
+      backgroundColor: AppColors.scaffoldColor,
       appBar: CustomAppBar(),
       body: SingleChildScrollView(
         child: ShabkaItemsChoicesListview()

--- a/lib/features/shabka_screen/presentation/view/widgets/shabka_listview.dart
+++ b/lib/features/shabka_screen/presentation/view/widgets/shabka_listview.dart
@@ -64,7 +64,7 @@ class ShabkaItemsChoicesListview extends StatelessWidget {
                 alignment: isArabic()? index%2==0?AlignmentDirectional.centerEnd:AlignmentDirectional.centerStart :index%2==0?AlignmentDirectional.centerStart:AlignmentDirectional.centerEnd ,
                 child: GestureDetector(
                   onTap: () {
-                    ControlNavigation().navigationToController(pageName: listviewData[index]["navigation"], context: context);
+                    ControlNavigation.navigationToController(pageName: listviewData[index]["navigation"], context: context);
                   },
                   child: Container(
                     width: 0.7.sw,

--- a/lib/features/wedding_items_screen/presentation/view/widgets/wedding_items_choices_listview.dart
+++ b/lib/features/wedding_items_screen/presentation/view/widgets/wedding_items_choices_listview.dart
@@ -64,7 +64,7 @@ class WeddingItemsChoicesListview extends StatelessWidget {
                 alignment: isArabic()? index%2==0?AlignmentDirectional.centerEnd:AlignmentDirectional.centerStart :index%2==0?AlignmentDirectional.centerStart:AlignmentDirectional.centerEnd ,
                 child: GestureDetector(
                   onTap: () {
-                    ControlNavigation().navigationToController(pageName: listviewData[index]["navigation"], context: context);
+                    ControlNavigation.navigationToController(pageName: listviewData[index]["navigation"], context: context);
                   },
                   child: Container(
                     width: 0.7.sw,

--- a/lib/features/wedding_preprations_screen/presentation/view/widgets/wedding_prep_listview_item.dart
+++ b/lib/features/wedding_preprations_screen/presentation/view/widgets/wedding_prep_listview_item.dart
@@ -35,7 +35,7 @@ class WeddingPrepListviewItem extends StatelessWidget {
                 GestureDetector(
                   onTap: () {
                     
-                  ControlNavigation().navigationToController(pageName: ScreenNames.advertisementScreen, context: context,
+                  ControlNavigation.navigationToController(pageName: ScreenNames.advertisementScreen, context: context,
                   arguments:{
                     "height":listviewData[index]["advImgHeight"],
                     "width":listviewData[index]["advImgWidth"],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ import 'package:zaghrota_app/features/invited_people_shabka_screen/presentation/
 import 'package:zaghrota_app/features/invited_people_shabka_screen/presentation/view_model/cubit/invited_people_screen_shabka_cubit.dart';
 import 'package:zaghrota_app/features/ka3at_screen/presentation/view/ka3at_screen.dart';
 import 'package:zaghrota_app/features/login_screen/presentation/view/login_screen.dart';
+import 'package:zaghrota_app/features/mohafazat_modn_screen/presentation/view/mohafzat_modn_screen.dart';
 import 'package:zaghrota_app/features/mohafzat_screen/presentation/view/mohafzat_screen.dart';
 import 'package:zaghrota_app/features/session_screen/presentation/view/session_screen.dart';
 import 'package:zaghrota_app/features/session_screen/presentation/view_model/cubit/session_screen_cubit.dart';
@@ -168,6 +169,7 @@ class MyApp extends StatelessWidget {
           ScreenNames.arosaDevicesMafroshatScreen:(context)=>const ArosaDevicesMafroshatScreen(),
           ScreenNames.arosaDevicesHoneymonthScreen:(context)=>const ArosaDevicesHonemonthScreen(),
           ScreenNames.arosaDevicesElectroScreen:(context)=>const ArosaDevicesElectronicsScreen(),
+          ScreenNames.modnScreen:(context)=>const MohafzatModnScreen(),
         },
         title: 'Flutter Demo',
         theme: AppTheme.theme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:zaghrota_app/core/database_helper/boxes_names.dart';
 import 'package:zaghrota_app/core/navigation/screen_names.dart';
 import 'package:zaghrota_app/features/advertisement_screen/presentation/view/advertisement_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/arosa_devices_bath_screen.dart';
+import 'package:zaghrota_app/features/arosa_devices_electronics_screen/presentation/view/arosa_devices_electronics_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_honeymonth_screen/presentation/view/arosa_devices_honemonth_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_kitchen_screen/presentation/view/arosa_devices_kitchen_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_mafroshat_screen/presentation/view/arosa_devices_mafroshat_screen.dart';
@@ -166,6 +167,7 @@ class MyApp extends StatelessWidget {
           ScreenNames.arosaDevicesKitchenScreen:(context)=>const ArosaDevicesKitchenScreen(),
           ScreenNames.arosaDevicesMafroshatScreen:(context)=>const ArosaDevicesMafroshatScreen(),
           ScreenNames.arosaDevicesHoneymonthScreen:(context)=>const ArosaDevicesHonemonthScreen(),
+          ScreenNames.arosaDevicesElectroScreen:(context)=>const ArosaDevicesElectronicsScreen(),
         },
         title: 'Flutter Demo',
         theme: AppTheme.theme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:zaghrota_app/core/navigation/screen_names.dart';
 import 'package:zaghrota_app/features/advertisement_screen/presentation/view/advertisement_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/arosa_devices_bath_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_kitchen_screen/presentation/view/arosa_devices_kitchen_screen.dart';
+import 'package:zaghrota_app/features/arosa_devices_mafroshat_screen/presentation/view/arosa_devices_mafroshat_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_screen/presentation/view/arosa_devices_screen.dart';
 import 'package:zaghrota_app/features/badla_screen/data/model/badla_model.dart';
 import 'package:zaghrota_app/features/badla_screen/presentation/view/badla_screen.dart';
@@ -162,6 +163,7 @@ class MyApp extends StatelessWidget {
               ),
           ScreenNames.arosaDevicesBathScreen:(context)=>const ArosaDevicesBathScreen(),
           ScreenNames.arosaDevicesKitchenScreen:(context)=>const ArosaDevicesKitchenScreen(),
+          ScreenNames.arosaDevicesMafroshatScreen:(context)=>const ArosaDevicesMafroshatScreen(),
         },
         title: 'Flutter Demo',
         theme: AppTheme.theme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:zaghrota_app/core/database_helper/boxes_names.dart';
 import 'package:zaghrota_app/core/navigation/screen_names.dart';
 import 'package:zaghrota_app/features/advertisement_screen/presentation/view/advertisement_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/arosa_devices_bath_screen.dart';
+import 'package:zaghrota_app/features/arosa_devices_honeymonth_screen/presentation/view/arosa_devices_honemonth_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_kitchen_screen/presentation/view/arosa_devices_kitchen_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_mafroshat_screen/presentation/view/arosa_devices_mafroshat_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_screen/presentation/view/arosa_devices_screen.dart';
@@ -164,6 +165,7 @@ class MyApp extends StatelessWidget {
           ScreenNames.arosaDevicesBathScreen:(context)=>const ArosaDevicesBathScreen(),
           ScreenNames.arosaDevicesKitchenScreen:(context)=>const ArosaDevicesKitchenScreen(),
           ScreenNames.arosaDevicesMafroshatScreen:(context)=>const ArosaDevicesMafroshatScreen(),
+          ScreenNames.arosaDevicesHoneymonthScreen:(context)=>const ArosaDevicesHonemonthScreen(),
         },
         title: 'Flutter Demo',
         theme: AppTheme.theme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:zaghrota_app/core/database_helper/boxes_names.dart';
 import 'package:zaghrota_app/core/navigation/screen_names.dart';
 import 'package:zaghrota_app/features/advertisement_screen/presentation/view/advertisement_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/arosa_devices_bath_screen.dart';
+import 'package:zaghrota_app/features/arosa_devices_kitchen_screen/presentation/view/arosa_devices_kitchen_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_screen/presentation/view/arosa_devices_screen.dart';
 import 'package:zaghrota_app/features/badla_screen/data/model/badla_model.dart';
 import 'package:zaghrota_app/features/badla_screen/presentation/view/badla_screen.dart';
@@ -159,7 +160,8 @@ class MyApp extends StatelessWidget {
                 create: (context) => FathaSongsScreenCubit()..getSongs(),
                 child: const FathaSongsScreen(),
               ),
-          ScreenNames.arosaDevicesBathScreen:(context)=>const ArosaDevicesBathScreen()
+          ScreenNames.arosaDevicesBathScreen:(context)=>const ArosaDevicesBathScreen(),
+          ScreenNames.arosaDevicesKitchenScreen:(context)=>const ArosaDevicesKitchenScreen(),
         },
         title: 'Flutter Demo',
         theme: AppTheme.theme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:zaghrota_app/core/app_Themes/app_theme.dart';
 import 'package:zaghrota_app/core/database_helper/boxes_names.dart';
 import 'package:zaghrota_app/core/navigation/screen_names.dart';
 import 'package:zaghrota_app/features/advertisement_screen/presentation/view/advertisement_screen.dart';
+import 'package:zaghrota_app/features/arosa_devices_bathroom_screen/presentation/view/arosa_devices_bath_screen.dart';
 import 'package:zaghrota_app/features/arosa_devices_screen/presentation/view/arosa_devices_screen.dart';
 import 'package:zaghrota_app/features/badla_screen/data/model/badla_model.dart';
 import 'package:zaghrota_app/features/badla_screen/presentation/view/badla_screen.dart';
@@ -157,7 +158,8 @@ class MyApp extends StatelessWidget {
           ScreenNames.fathaSongsScreen: (context) =>  BlocProvider(
                 create: (context) => FathaSongsScreenCubit()..getSongs(),
                 child: const FathaSongsScreen(),
-              )
+              ),
+          ScreenNames.arosaDevicesBathScreen:(context)=>const ArosaDevicesBathScreen()
         },
         title: 'Flutter Demo',
         theme: AppTheme.theme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,8 @@ import 'package:zaghrota_app/features/badla_screen/presentation/view_model/cubit
 import 'package:zaghrota_app/features/default_screen/default_screen.dart';
 import 'package:zaghrota_app/features/dress_screen/presentation/view/dress_screen.dart';
 import 'package:zaghrota_app/features/dress_screen/presentation/view_model/cubit/dress_screen_cubit.dart';
+import 'package:zaghrota_app/features/fatha_ma3azzem_screen/presentation/view/fatha_ma3aazeem_invited_people_screen.dart';
+import 'package:zaghrota_app/features/fatha_ma3azzem_screen/presentation/view_model/cubit/fatha_invited_people_screen_cubit.dart';
 import 'package:zaghrota_app/features/fatha_screen/presentation/view/fatha_screen.dart';
 import 'package:zaghrota_app/features/fatha_songs_screen/presentation/view/fatha_songs_screen.dart';
 import 'package:zaghrota_app/features/fatha_songs_screen/presentation/view_model/cubit/fatha_songs_screen_cubit.dart';
@@ -60,6 +62,7 @@ void main() async {
   await Hive.openBox<InvitedModel>(BoxesNames.invitedPeoples);
   await Hive.openBox<InvitedModel>(BoxesNames.invitedPeopleHena);
   await Hive.openBox<InvitedModel>(BoxesNames.invitedPeopleShabka);
+  await Hive.openBox<InvitedModel>(BoxesNames.invitedPeopleFatha);
   await Hive.openBox<BadlaModel>(BoxesNames.badlaitems);
   await Hive.openBox<bool>(BoxesNames.dressChecks);
   await Hive.openBox<bool>(BoxesNames.sessionChecks);
@@ -160,16 +163,25 @@ class MyApp extends StatelessWidget {
                 create: (context) => ShabkaSongsScreenCubit()..getSongs(),
                 child: const ShabkaSongsScreen(),
               ),
-          ScreenNames.fathaSongsScreen: (context) =>  BlocProvider(
+          ScreenNames.fathaSongsScreen: (context) => BlocProvider(
                 create: (context) => FathaSongsScreenCubit()..getSongs(),
                 child: const FathaSongsScreen(),
               ),
-          ScreenNames.arosaDevicesBathScreen:(context)=>const ArosaDevicesBathScreen(),
-          ScreenNames.arosaDevicesKitchenScreen:(context)=>const ArosaDevicesKitchenScreen(),
-          ScreenNames.arosaDevicesMafroshatScreen:(context)=>const ArosaDevicesMafroshatScreen(),
-          ScreenNames.arosaDevicesHoneymonthScreen:(context)=>const ArosaDevicesHonemonthScreen(),
-          ScreenNames.arosaDevicesElectroScreen:(context)=>const ArosaDevicesElectronicsScreen(),
-          ScreenNames.modnScreen:(context)=>const MohafzatModnScreen(),
+          ScreenNames.arosaDevicesBathScreen: (context) =>
+              const ArosaDevicesBathScreen(),
+          ScreenNames.arosaDevicesKitchenScreen: (context) =>
+              const ArosaDevicesKitchenScreen(),
+          ScreenNames.arosaDevicesMafroshatScreen: (context) =>
+              const ArosaDevicesMafroshatScreen(),
+          ScreenNames.arosaDevicesHoneymonthScreen: (context) =>
+              const ArosaDevicesHonemonthScreen(),
+          ScreenNames.arosaDevicesElectroScreen: (context) =>
+              const ArosaDevicesElectronicsScreen(),
+          ScreenNames.modnScreen: (context) => const MohafzatModnScreen(),
+          ScreenNames.invitedPeopleFathaScreen: (context) => BlocProvider(
+                create: (context) => FathaInvitedPeopleScreenCubit()..getInvitedPeople(),
+                child: const FathaMa3aazeemInvitedPeopleScreen(),
+              )
         },
         title: 'Flutter Demo',
         theme: AppTheme.theme,


### PR DESCRIPTION
- Add fatha ma3azeem screen to screen names.
- Add fatha ma3azeem screen to control navigation.
- Add fatha ma3azeem screen to routes of main.
- Create fatha ma3azeem screen by new and past components.
- Create fatha ma3azeem screen repo.
- Create fatha ma3azeem screen cubit.
- Open fatha ma3azeem box in hive.
- Consuming fatha ma3azeem screen cubit on fatha ma3azeem screen components.
![WhatsApp Image 2024-10-13 at 2 55 27 PM (1)](https://github.com/user-attachments/assets/a3be2329-f204-4120-a895-ee55f0bfb732)
